### PR TITLE
fix main directory file path for handwriting computer.

### DIFF
--- a/server/process.R
+++ b/server/process.R
@@ -77,7 +77,7 @@ switch(Sys.info()[['sysname']],
          if (dir.exists("/lss/research/csafe-handwriting-irb/Data_Processing_App_Testing")){
            paths$main_dir = "/lss/research/csafe-handwriting-irb/Data_Processing_App_Testing"
          } else if (dir.exists("Y:/Data_Processing_App_Testing")){
-           paths$main_dir = "/lss/research/csafe-handwriting-irb/Data_Processing_App_Testing"
+           paths$main_dir = "Y:/Data_Processing_App_Testing"
          }
        },
 )


### PR DESCRIPTION
The handwriting computer has the csafe-handwriting-irb folder mounted as the Y-drive. The app was trying to reach the folder through /lss/research/... which throws an error. I changed the main directory to Y:/Data_Processig_App_Testing if this directory exists.